### PR TITLE
Support some bodies always being rendered on top of other bodies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janelia/sharkviewer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janelia/sharkviewer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "SWC neuron file viewer",
   "main": "dist/shark_viewer.js",
   "peerDependencies": {


### PR DESCRIPTION
To be used by neuPrintExplorer, to optionally show synapses on top, the way NeuTu does.